### PR TITLE
✨ Tasks

### DIFF
--- a/src/main/kotlin/at/phatbl/fork/FetchRemoteTask.kt
+++ b/src/main/kotlin/at/phatbl/fork/FetchRemoteTask.kt
@@ -8,7 +8,7 @@ open class FetchRemoteTask : ShellExec() {
     lateinit var remoteName: String
 
     init {
-        group = "Fork"
+        group = "\uD83C\uDF74 Fork"
     }
 
     /**

--- a/src/main/kotlin/at/phatbl/fork/FetchRemoteTask.kt
+++ b/src/main/kotlin/at/phatbl/fork/FetchRemoteTask.kt
@@ -7,6 +7,10 @@ open class FetchRemoteTask : ShellExec() {
     @Input
     lateinit var remoteName: String
 
+    init {
+        group = "Fork"
+    }
+
     /**
      * Builds the git command.
      */

--- a/src/main/kotlin/at/phatbl/fork/ForkPlugin.kt
+++ b/src/main/kotlin/at/phatbl/fork/ForkPlugin.kt
@@ -2,6 +2,7 @@ package at.phatbl.fork
 
 import at.phatbl.fork.model.GitHubRemote
 import at.phatbl.fork.model.Remote
+import at.phatbl.fork.tasks.AddRemoteTask
 import at.phatbl.fork.tasks.FetchRemoteTask
 import org.ajoberstar.grgit.Grgit
 import org.ajoberstar.grgit.Remote as GRemote
@@ -141,6 +142,13 @@ class ForkPlugin : Plugin<Project> {
      * Creates gradle tasks.
      */
     fun createTasks(project: Project) {
+        // Add upstream remote to git
+        project.tasks.create("addRemoteUpstream", AddRemoteTask::class.java).apply {
+            remoteName = "upstream"
+            url = upstream.url
+            description = "Adds the upstream remote, if missing."
+        }
+        
         // Create fetch task for each remote
         listOf(origin.name, upstream.name).forEach { remote ->
             project.tasks.create("fetch${remote.capitalize()}", FetchRemoteTask::class.java).apply {

--- a/src/main/kotlin/at/phatbl/fork/ForkPlugin.kt
+++ b/src/main/kotlin/at/phatbl/fork/ForkPlugin.kt
@@ -4,6 +4,7 @@ import at.phatbl.fork.model.GitHubRemote
 import at.phatbl.fork.model.Remote
 import at.phatbl.fork.tasks.AddRemoteTask
 import at.phatbl.fork.tasks.FetchRemoteTask
+import at.phatbl.fork.tasks.PushRemoteTask
 import org.ajoberstar.grgit.Grgit
 import org.ajoberstar.grgit.Remote as GRemote
 import org.gradle.api.GradleException
@@ -148,13 +149,19 @@ class ForkPlugin : Plugin<Project> {
             url = upstream.url
             description = "Adds the upstream remote, if missing."
         }
-        
+
         // Create fetch task for each remote
         listOf(origin.name, upstream.name).forEach { remote ->
             project.tasks.create("fetch${remote.capitalize()}", FetchRemoteTask::class.java).apply {
                 remoteName = remote
                 description = "Fetches the $remote remote."
             }
+        }
+
+        // Add upstream remote to git
+        project.tasks.create("pushRemote${origin.name.capitalize()}", PushRemoteTask::class.java).apply {
+            remoteName = origin.name
+            description = "Pushes the ${origin.name} remote."
         }
     }
 }

--- a/src/main/kotlin/at/phatbl/fork/ForkPlugin.kt
+++ b/src/main/kotlin/at/phatbl/fork/ForkPlugin.kt
@@ -49,15 +49,18 @@ class ForkPlugin : Plugin<Project> {
     }
 
     /**
-     * Walks up from the current dir looking for the root dir which contains a .git dir.
+     * Look in the current dir and parent for a .git dir which indicates the git root.
      * This allows for the plugin to be applied from a subfolder or the root (e.g. from tests).
      */
     fun findGitRoot(currentDir: File): File {
-        val gitDir = currentDir.parentFile.walkTopDown().maxDepth(2).find {
-            file -> file.name == ".git"
-        } ?: throw GradleException("Could not find .git dir")
+        listOf(currentDir, currentDir.parentFile).forEach { folder ->
+            val gitDir = folder.listFiles().find { file -> file.name == ".git" }
+            if (gitDir != null) {
+                return gitDir.parentFile
+            }
+        }
 
-        return gitDir.parentFile
+        throw GradleException("Could not find .git dir")
     }
 
     /**

--- a/src/main/kotlin/at/phatbl/fork/ForkPlugin.kt
+++ b/src/main/kotlin/at/phatbl/fork/ForkPlugin.kt
@@ -2,6 +2,7 @@ package at.phatbl.fork
 
 import at.phatbl.fork.model.GitHubRemote
 import at.phatbl.fork.model.Remote
+import at.phatbl.fork.tasks.FetchRemoteTask
 import org.ajoberstar.grgit.Grgit
 import org.ajoberstar.grgit.Remote as GRemote
 import org.gradle.api.GradleException

--- a/src/main/kotlin/at/phatbl/fork/ForkPlugin.kt
+++ b/src/main/kotlin/at/phatbl/fork/ForkPlugin.kt
@@ -152,7 +152,7 @@ class ForkPlugin : Plugin<Project> {
 
         // Create fetch task for each remote
         listOf(origin.name, upstream.name).forEach { remote ->
-            project.tasks.create("fetch${remote.capitalize()}", FetchRemoteTask::class.java).apply {
+            project.tasks.create("fetchRemote${remote.capitalize()}", FetchRemoteTask::class.java).apply {
                 remoteName = remote
                 description = "Fetches the $remote remote."
             }

--- a/src/main/kotlin/at/phatbl/fork/ForkPlugin.kt
+++ b/src/main/kotlin/at/phatbl/fork/ForkPlugin.kt
@@ -41,6 +41,7 @@ class ForkPlugin : Plugin<Project> {
         project.afterEvaluate {
             try {
                 buildModel(extension)
+                createTasks(project)
             } catch (error: Exception) {
                 project.logger.error("Error configuring project: ${error.localizedMessage}.\nFork plugin is disabled.")
             }
@@ -117,5 +118,18 @@ class ForkPlugin : Plugin<Project> {
         //Tip
         //This support must be explicitly enabled with the system property org.ajoberstar.grgit.auth.command.allow=true.
         System.setProperty("org.ajoberstar.grgit.auth.command.allow", "true")
+    }
+
+    /**
+     * Creates gradle tasks.
+     */
+    fun createTasks(project: Project) {
+        // Create fetch task for each remote
+        listOf("origin", "upstream").forEach { remote ->
+            project.tasks.create("fetch${remote.capitalize()}", FetchRemoteTask::class.java).apply {
+                remoteName = remote
+                description = "Fetches the $remote remote."
+            }
+        }
     }
 }

--- a/src/main/kotlin/at/phatbl/fork/model/GitHubRemote.kt
+++ b/src/main/kotlin/at/phatbl/fork/model/GitHubRemote.kt
@@ -5,10 +5,11 @@ import org.ajoberstar.grgit.Remote as GRemote
 
 class GitHubRemote(
         val owner: String,
-        repo: String
+        name: String = owner,
+        repoName: String
 ) : Remote(
-        name = owner,
-        url = "https://github.com/$owner/$repo.git"
+        name = name,
+        url = "https://github.com/$owner/$repoName.git"
 ) {
     private val validatedUrl: URL = URL(url)
 

--- a/src/main/kotlin/at/phatbl/fork/tasks/AddRemoteTask.kt
+++ b/src/main/kotlin/at/phatbl/fork/tasks/AddRemoteTask.kt
@@ -1,0 +1,33 @@
+package at.phatbl.fork.tasks
+
+import at.phatbl.shellexec.ShellCommand
+import at.phatbl.shellexec.ShellExec
+import org.gradle.api.tasks.Input
+
+open class AddRemoteTask : ShellExec() {
+    @Input
+    lateinit var remoteName: String
+
+    @Input
+    lateinit var url: String
+
+    init {
+        group = "\uD83C\uDF74 Fork"
+
+        onlyIf {
+            val detectExisting = ShellCommand(project.rootDir, "git remote | grep '^upstream'")
+            detectExisting.start()
+            print(detectExisting.stdout)
+            // Only add if remote isn't found
+            detectExisting.failed
+        }
+    }
+
+    /**
+     * Builds the git command.
+     */
+    override fun preExec() {
+        super.preExec()
+        command = "git add $remoteName $url"
+    }
+}

--- a/src/main/kotlin/at/phatbl/fork/tasks/FetchRemoteTask.kt
+++ b/src/main/kotlin/at/phatbl/fork/tasks/FetchRemoteTask.kt
@@ -1,4 +1,4 @@
-package at.phatbl.fork
+package at.phatbl.fork.tasks
 
 import at.phatbl.shellexec.ShellExec
 import org.gradle.api.tasks.Input

--- a/src/main/kotlin/at/phatbl/fork/tasks/PushRemoteTask.kt
+++ b/src/main/kotlin/at/phatbl/fork/tasks/PushRemoteTask.kt
@@ -1,0 +1,21 @@
+package at.phatbl.fork.tasks
+
+import at.phatbl.shellexec.ShellExec
+import org.gradle.api.tasks.Input
+
+open class PushRemoteTask : ShellExec() {
+    @Input
+    lateinit var remoteName: String
+
+    init {
+        group = "\uD83C\uDF74 Fork"
+    }
+
+    /**
+     * Builds the git command.
+     */
+    override fun preExec() {
+        super.preExec()
+        command = "git push $remoteName"
+    }
+}

--- a/src/test/kotlin/at/phatbl/fork/ForkPluginSpek.kt
+++ b/src/test/kotlin/at/phatbl/fork/ForkPluginSpek.kt
@@ -56,19 +56,36 @@ object ForkPluginSpek : Spek({
                 }
             }
         }
-        on("build origin") {
-            val gRemote = GRemote(hashMapOf(
-                    "name" to "owner",
-                    "url" to "https://github.com/owner/repo.git"
-            ))
-            val remote = plugin.buildOrigin(gRemote)
-            it("creates a github remote") {
-                assertNotNull(remote)
-                assertTrue {
-                    remote is GitHubRemote && remote.owner == "owner"
+        context("build origin") {
+            on("matching owner and remote name") {
+                val gRemote = GRemote(hashMapOf(
+                        "name" to "owner",
+                        "url" to "https://github.com/owner/repo.git"
+                ))
+                val remote = plugin.buildOrigin(gRemote)
+                it("creates a github remote") {
+                    assertNotNull(remote)
+                    assertTrue {
+                        remote is GitHubRemote && remote.owner == "owner"
+                    }
+                    assertEquals("owner", remote.name)
+                    assertEquals("github.com", remote.hostname)
                 }
-                assertEquals("owner", remote.name)
-                assertEquals("github.com", remote.hostname)
+            }
+            on("different owner and remote names") {
+                val gRemote = GRemote(hashMapOf(
+                        "name" to "upstream",
+                        "url" to "https://github.com/owner/repo.git"
+                ))
+                val remote = plugin.buildOrigin(gRemote)
+                it("creates a github remote") {
+                    assertNotNull(remote)
+                    assertTrue {
+                        remote is GitHubRemote && remote.owner == "owner"
+                    }
+                    assertEquals("upstream", remote.name)
+                    assertEquals("github.com", remote.hostname)
+                }
             }
         }
         on("parse upstream") {
@@ -78,7 +95,7 @@ object ForkPluginSpek : Spek({
                 assertTrue {
                     remote is GitHubRemote && remote.owner == "owner"
                 }
-                assertEquals("owner", remote.name)
+                assertEquals("upstream", remote.name)
                 assertEquals("github.com", remote.hostname)
             }
         }

--- a/src/test/kotlin/at/phatbl/fork/ForkPluginSpek.kt
+++ b/src/test/kotlin/at/phatbl/fork/ForkPluginSpek.kt
@@ -127,12 +127,12 @@ object ForkPluginSpek : Spek({
                 assertTrue { task is AddRemoteTask }
             }
             it("creates a fetch remote task for origin") {
-                val task = project.tasks.getByName("fetchOrigin")
+                val task = project.tasks.getByName("fetchRemoteOrigin")
                 assertNotNull(task)
                 assertTrue { task is FetchRemoteTask }
             }
             it("creates a fetch remote task for upstream") {
-                val task = project.tasks.getByName("fetchUpstream")
+                val task = project.tasks.getByName("fetchRemoteUpstream")
                 assertNotNull(task)
                 assertTrue { task is FetchRemoteTask }
             }

--- a/src/test/kotlin/at/phatbl/fork/ForkPluginSpek.kt
+++ b/src/test/kotlin/at/phatbl/fork/ForkPluginSpek.kt
@@ -1,6 +1,9 @@
 package at.phatbl.fork
 
 import at.phatbl.fork.model.GitHubRemote
+import at.phatbl.fork.tasks.AddRemoteTask
+import at.phatbl.fork.tasks.FetchRemoteTask
+import at.phatbl.fork.tasks.PushRemoteTask
 import at.phatbl.shellexec.ShellCommand
 import org.gradle.api.GradleException
 import org.gradle.testfixtures.ProjectBuilder
@@ -104,6 +107,39 @@ object ForkPluginSpek : Spek({
                 Assertions.assertThrows(GradleException::class.java) {
                     plugin.parseUpstream("not a valid github reference")
                 }
+            }
+        }
+        on("create tasks") {
+            plugin.origin = GitHubRemote(
+                    name = "origin",
+                    owner = "phatblat",
+                    repoName = "Fork"
+            )
+            plugin.upstream = GitHubRemote(
+                    name = "upstream",
+                    owner = "phatblat",
+                    repoName = "Fork"
+            )
+            plugin.createTasks(project)
+            it("creates an add remote task") {
+                val task = project.tasks.getByName("addRemoteUpstream")
+                assertNotNull(task)
+                assertTrue { task is AddRemoteTask }
+            }
+            it("creates a fetch remote task for origin") {
+                val task = project.tasks.getByName("fetchOrigin")
+                assertNotNull(task)
+                assertTrue { task is FetchRemoteTask }
+            }
+            it("creates a fetch remote task for upstream") {
+                val task = project.tasks.getByName("fetchUpstream")
+                assertNotNull(task)
+                assertTrue { task is FetchRemoteTask }
+            }
+            it("creates a push remote task") {
+                val task = project.tasks.getByName("pushRemoteOrigin")
+                assertNotNull(task)
+                assertTrue { task is PushRemoteTask }
             }
         }
     }

--- a/src/test/kotlin/at/phatbl/fork/tasks/AddRemoteTaskSpek.kt
+++ b/src/test/kotlin/at/phatbl/fork/tasks/AddRemoteTaskSpek.kt
@@ -7,15 +7,16 @@ import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.api.dsl.on
 import kotlin.test.assertEquals
 
-object FetchRemoteTaskSpek : Spek({
-    describe("fetch remote task") {
+object AddRemoteTaskSpek : Spek({
+    describe("add remote task") {
         val project = ProjectBuilder.builder().build()
-        val task = project.tasks.create("fetchRemote", FetchRemoteTask::class.java)
+        val task = project.tasks.create("addRemote", AddRemoteTask::class.java)
         on("pre-execute") {
             task.remoteName = "upstream"
+            task.url = "git@github.com:phatblat/Fork.git"
             it("builds a git command") {
                 task.preExec()
-                assertEquals("git fetch upstream", task.command)
+                assertEquals("git add upstream git@github.com:phatblat/Fork.git", task.command)
             }
         }
     }

--- a/src/test/kotlin/at/phatbl/fork/tasks/FetchRemoteTaskSpek.kt
+++ b/src/test/kotlin/at/phatbl/fork/tasks/FetchRemoteTaskSpek.kt
@@ -1,4 +1,4 @@
-package at.phatbl.fork
+package at.phatbl.fork.tasks
 
 import org.gradle.testfixtures.ProjectBuilder
 import org.jetbrains.spek.api.Spek

--- a/src/test/kotlin/at/phatbl/fork/tasks/PushRemoteTaskSpek.kt
+++ b/src/test/kotlin/at/phatbl/fork/tasks/PushRemoteTaskSpek.kt
@@ -1,0 +1,22 @@
+package at.phatbl.fork.tasks
+
+import org.gradle.testfixtures.ProjectBuilder
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.api.dsl.on
+import kotlin.test.assertEquals
+
+object PushRemoteTaskSpek : Spek({
+    describe("push remote task") {
+        val project = ProjectBuilder.builder().build()
+        val task = project.tasks.create("pushRemote", PushRemoteTask::class.java)
+        on("pre-execute") {
+            task.remoteName = "origin"
+            it("builds a git command") {
+                task.preExec()
+                assertEquals("git push origin", task.command)
+            }
+        }
+    }
+})


### PR DESCRIPTION
Added tasks for each of the following:

- `addRemoteUpstream`
- `fetchRemoteOrigin` (or current name of origin)
- `fetchRemoteUpstream`
- `pushRemoteOrigin` (or current name of origin)

Note that the origin remote may not be named `origin`. The first remote discovered will be treated as origin and the above tasks will use have the actual remote name in them instead of "Origin".